### PR TITLE
perf(java-interface-serializer-supply): changed serializer into supplier

### DIFF
--- a/src/main/java/io/apimatic/coreinterfaces/type/functional/Serializer.java
+++ b/src/main/java/io/apimatic/coreinterfaces/type/functional/Serializer.java
@@ -11,9 +11,8 @@ public interface Serializer {
     /**
      * Apply the serialization function and returns the serialized string
      * 
-     * @param responseData the function for serialization
      * @return the serialized string
      * @throws IOException Exception to be thrown while applying the function.
      */
-    String apply(Object responseData) throws IOException;
+    String supply() throws IOException;
 }


### PR DESCRIPTION
A body serializer was a functional interface that was causing the problem of type inferring.  So, I changed the functional interface to the supplier interface which performs the function and supplies the output in string format.

closes #7