### PR TITLE
build(upgrade  version): upgrade the version of OkhttpClient version

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ To add a dependency on core interfaces using Maven, use the following:
 <dependency>
     <groupId>io.apimatic</groupId>
     <artifactId>core-interfaces</artifactId>
-    <version>0.1.2</version>
+    <version>0.1.3</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
 	<groupId>io.apimatic</groupId>
 	<artifactId>core-interfaces</artifactId>
-	<version>0.1.2</version>
+	<version>0.1.3</version>
 
 	<name>core-interfaces</name>
 	<description>An abstract layer of the functionalities provided by apimatic-core-library, okhttp-client-adapter and APIMatic SDKs.</description>
@@ -49,7 +49,7 @@
 		<dependency>
 			<groupId>com.squareup.okhttp3</groupId>
 			<artifactId>okhttp</artifactId>
-			<version>4.9.1</version>
+			<version>4.10.0</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
Moved OkhttpClient's version from 4.9.1 to LTS 4.10.0. And Upgrade the core interfaces version

closes #15