### PR TITLE
fix(add the handling of dynamic api response): add dynamic api response

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ To add a dependency on core interfaces using Maven, use the following:
 <dependency>
     <groupId>io.apimatic</groupId>
     <artifactId>core-interfaces</artifactId>
-    <version>0.1.3</version>
+    <version>0.1.4</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
 	<groupId>io.apimatic</groupId>
 	<artifactId>core-interfaces</artifactId>
-	<version>0.1.3</version>
+	<version>0.1.4</version>
 
 	<name>core-interfaces</name>
 	<description>An abstract layer of the functionalities provided by apimatic-core-library, okhttp-client-adapter and APIMatic SDKs.</description>

--- a/src/main/java/io/apimatic/coreinterfaces/http/request/ResponseClassType.java
+++ b/src/main/java/io/apimatic/coreinterfaces/http/request/ResponseClassType.java
@@ -5,5 +5,5 @@ package io.apimatic.coreinterfaces.http.request;
  *
  */
 public enum ResponseClassType {
-    API_RESPONSE, DYNAMIC_RESPONSE
+    API_RESPONSE, DYNAMIC_RESPONSE, DYNAMIC_API_RESPONSE
 }


### PR DESCRIPTION
This PR contains the fix of the issue in which ApiResponse encapsulates the Dynamic Response. There is no JSON creator on SDK level so we cannot deserialize that

closes #19