### PR TITLE
refactor(remove-parse-exception): removed parse exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ To add a dependency on core interfaces using Maven, use the following:
 <dependency>
     <groupId>io.apimatic</groupId>
     <artifactId>core-interfaces</artifactId>
-    <version>0.1.4</version>
+    <version>0.1.5</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
 	<groupId>io.apimatic</groupId>
 	<artifactId>core-interfaces</artifactId>
-	<version>0.1.4</version>
+	<version>0.1.5</version>
 
 	<name>core-interfaces</name>
 	<description>An abstract layer of the functionalities provided by apimatic-core-library, okhttp-client-adapter and APIMatic SDKs.</description>

--- a/src/main/java/io/apimatic/coreinterfaces/http/response/DynamicType.java
+++ b/src/main/java/io/apimatic/coreinterfaces/http/response/DynamicType.java
@@ -90,9 +90,8 @@ public interface DynamicType {
      * Parse response as string.
      * 
      * @return Parsed value
-     * @throws ParseException Signals if a parse exception occured
      */
-    String parseAsString() throws ParseException;
+    String parseAsString();
 
     /**
      * Parse response as a map of keys and values.


### PR DESCRIPTION
DynamicType interface has a method named parseAsString which is throwing the ParseException. There is no need to throw the parse Exception because its return type is a string so there is no parsing involved.

closes #21