### PR TITLE
ci(add-release-ci-script): add the release ci script to publish maven

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release To Maven
+name: Release To Maven Central
 
 # Run workflow on commits to the `main` branch
 on:
@@ -15,21 +15,21 @@ on:
 
 jobs:
   publish:
-    name: Creating release version
+    name: Publish the Maven package
     runs-on: ubuntu-latest
     environment: Production
     steps:
-      - name: Check out Git repository
+      - name: Check out git repository
         uses: actions/checkout@v2
 
-      - name: Install Java and Maven
+      - name: Install Java and Maven setup
         uses: actions/setup-java@v1
         with:
           java-version: 8
           
-      - name: Update version in pom.xml (Release only)
+      - name: Update version in POM
         run: mvn -B versions:set -DnewVersion=${{ github.event.inputs.Version }} -DgenerateBackupPoms=false
-      - name: Create Tag
+      - name: Create tag
         id: tag_version
         uses: mathieudutour/github-tag-action@v6.0
         with:
@@ -37,13 +37,13 @@ jobs:
           custom_tag: ${{ github.event.inputs.Version }}
           tag_prefix: ""
           
-      - name: Create release
+      - name: Create changelog for the release
         uses: ncipollo/release-action@v1
         with: 
           tag: ${{ steps.tag_version.outputs.new_tag }}
           name: Release ${{ github.event.inputs.Title }}
           body: ${{ steps.tag_version.outputs.changelog }}
-      - name: Release Maven package
+      - name: Release to Maven Central
         id: release
         uses: samuelmeuli/action-maven-publish@v1
         with:
@@ -51,7 +51,7 @@ jobs:
           gpg_passphrase: ${{ secrets.OSSRH_GPG_PASSPHRASE  }}
           nexus_username: ${{ secrets.OSSRH_USERNAME  }}
           nexus_password: ${{ secrets.OSSRH_PASSWORD }}
-      - name: Run the commit action
+      - name: Commit the version change
         if: steps.release.outputs.exit_code == 0
         uses: devops-infra/action-commit-push@master
         with:
@@ -60,7 +60,7 @@ jobs:
            commit_message: "ci(release-version): update pom.xml [ci skip]"
            force: false
            target_branch: ${{ github.ref }}
-      - name: Push changes
+      - name: Push the version change
         if: steps.release.outputs.exit_code == 0
         uses: ad-m/github-push-action@master
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,20 +29,6 @@ jobs:
           
       - name: Update version in POM
         run: mvn -B versions:set -DnewVersion=${{ github.event.inputs.Version }} -DgenerateBackupPoms=false
-      - name: Create tag
-        id: tag_version
-        uses: mathieudutour/github-tag-action@v6.0
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          custom_tag: ${{ github.event.inputs.Version }}
-          tag_prefix: ""
-          
-      - name: Create changelog for the release
-        uses: ncipollo/release-action@v1
-        with: 
-          tag: ${{ steps.tag_version.outputs.new_tag }}
-          name: Release ${{ github.event.inputs.Title }}
-          body: ${{ steps.tag_version.outputs.changelog }}
       - name: Release to Maven Central
         id: release
         uses: samuelmeuli/action-maven-publish@v1
@@ -66,3 +52,19 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: ${{ github.ref }}
+      - name: Create tag
+        if: steps.release.outputs.exit_code == 0
+        id: tag_version
+        uses: mathieudutour/github-tag-action@v6.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          custom_tag: ${{ github.event.inputs.Version }}
+          tag_prefix: ""
+          
+      - name: Create changelog for the release
+        if: steps.release.outputs.exit_code == 0
+        uses: ncipollo/release-action@v1
+        with: 
+          tag: ${{ steps.tag_version.outputs.new_tag }}
+          name: Release ${{ github.event.inputs.Title }}
+          body: ${{ steps.tag_version.outputs.changelog }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,19 +29,6 @@ jobs:
           
       - name: Update version in pom.xml (Release only)
         run: mvn -B versions:set -DnewVersion=${{ github.event.inputs.Version }} -DgenerateBackupPoms=false
-      - name: Run the commit action
-        uses: devops-infra/action-commit-push@master
-        with:
-           github_token: "${{ secrets.GITHUB_TOKEN }}"
-           add_timestamp: true
-           commit_message: "ci(release-version): update pom.xml [ci skip]"
-           force: false
-           target_branch: ${{ github.ref }}
-      - name: Push changes
-        uses: ad-m/github-push-action@master
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          branch: ${{ github.ref }}
       - name: Create Tag
         id: tag_version
         uses: mathieudutour/github-tag-action@v6.0
@@ -57,9 +44,25 @@ jobs:
           name: Release ${{ github.event.inputs.Title }}
           body: ${{ steps.tag_version.outputs.changelog }}
       - name: Release Maven package
+        id: release
         uses: samuelmeuli/action-maven-publish@v1
         with:
           gpg_private_key: ${{ secrets.OSSRH_GPG_SECRET_KEY  }}
           gpg_passphrase: ${{ secrets.OSSRH_GPG_PASSPHRASE  }}
           nexus_username: ${{ secrets.OSSRH_USERNAME  }}
           nexus_password: ${{ secrets.OSSRH_PASSWORD }}
+      - name: Run the commit action
+        if: steps.release.outputs.exit_code == 0
+        uses: devops-infra/action-commit-push@master
+        with:
+           github_token: "${{ secrets.GITHUB_TOKEN }}"
+           add_timestamp: true
+           commit_message: "ci(release-version): update pom.xml [ci skip]"
+           force: false
+           target_branch: ${{ github.ref }}
+      - name: Push changes
+        if: steps.release.outputs.exit_code == 0
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ github.ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,65 @@
+name: Release To Maven
+
+# Run workflow on commits to the `main` branch
+on:
+   workflow_dispatch:
+    inputs:
+      Version:
+        description: "Version to be released in format: x.y.z, where x => major version, y => minor version and z => patch version"
+        required: true
+        default: "0.1.0"
+      Title:
+        description: "Title of the release"
+        required: true
+        default: "Improving API developer experience"
+
+jobs:
+  publish:
+    name: Creating release version
+    runs-on: ubuntu-latest
+    environment: Production
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v2
+
+      - name: Install Java and Maven
+        uses: actions/setup-java@v1
+        with:
+          java-version: 8
+          
+      - name: Update version in pom.xml (Release only)
+        run: mvn -B versions:set -DnewVersion=${{ github.event.inputs.Version }} -DgenerateBackupPoms=false
+      - name: Run the commit action
+        uses: devops-infra/action-commit-push@master
+        with:
+           github_token: "${{ secrets.GITHUB_TOKEN }}"
+           add_timestamp: true
+           commit_message: "ci(release-version): update pom.xml [ci skip]"
+           force: false
+           target_branch: ${{ github.ref }}
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ github.ref }}
+      - name: Create Tag
+        id: tag_version
+        uses: mathieudutour/github-tag-action@v6.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          custom_tag: ${{ github.event.inputs.Version }}
+          tag_prefix: ""
+          
+      - name: Create release
+        uses: ncipollo/release-action@v1
+        with: 
+          tag: ${{ steps.tag_version.outputs.new_tag }}
+          name: Release ${{ github.event.inputs.Title }}
+          body: ${{ steps.tag_version.outputs.changelog }}
+      - name: Release Maven package
+        uses: samuelmeuli/action-maven-publish@v1
+        with:
+          gpg_private_key: ${{ secrets.OSSRH_GPG_SECRET_KEY  }}
+          gpg_passphrase: ${{ secrets.OSSRH_GPG_PASSPHRASE  }}
+          nexus_username: ${{ secrets.OSSRH_USERNAME  }}
+          nexus_password: ${{ secrets.OSSRH_PASSWORD }}

--- a/README.md
+++ b/README.md
@@ -9,14 +9,6 @@ This project contains the abstract layer for APIMatic's core library and Apimati
 * The JRE flavor requires `JDK 1.8`.
 ## Install the maven package
 Core Interfaces's Maven group ID is `io.apimatic`, and its artifact ID is `core-interfaces`.
-To add a dependency on core interfaces using Maven, use the following:
-```java
-<dependency>
-    <groupId>io.apimatic</groupId>
-    <artifactId>core-interfaces</artifactId>
-    <version>0.1.4</version>
-</dependency>
-```
 
 ## Interfaces
 | Name                                                                    | Description                                                        |


### PR DESCRIPTION
A ci script is added for the release maven package which takes the release version as input. Create the release tag against that and update the pom file as well. Used the GitHub action to automatically create the changelog and use the input title, as the title of the changelog.

closes #29