### PR TITLE
fix(add-pinentry-mode): add pinentry-mode to sign the artifcats

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -171,6 +171,12 @@
 						<goals>
 							<goal>sign</goal>
 						</goals>
+						<configuration>
+							<gpgArguments>
+								<arg>--pinentry-mode</arg>
+								<arg>loopback</arg>
+							</gpgArguments>
+						</configuration>
 					</execution>
 				</executions>
 			</plugin>


### PR DESCRIPTION
Setup the pinentry-mode to sign the artifacts. Loopback mode allows Fluidkeys to send a password directly to GnuPG, rather than GnuPG itself prompting for the password.

closes #33