### PR TITLE
ci: add Github action for SonarQube scan

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
   pull_request:
+    branches:
+      - main
 
 jobs:
   build-and-test:
@@ -20,4 +22,11 @@ jobs:
         cache: maven
     - name: Build with Maven
       run: mvn -B package --file pom.xml
+
+    - name: SonarQube Scan
+      if: ${{ github.actor != 'dependabot[bot]' }}
+      uses: SonarSource/sonarqube-scan-action@v5.2.0
+      env:
+        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 [![Maven Central][maven-badge]][maven-url]
 [![Tests][test-badge]][test-url]
 [![Lint Code][lint-badge]][lint-url]
-[![Maintainability][maintainability-url]][code-climate-url]
+[![Maintainability Rating][maintainability-badge]][maintainability-url]
+[![Vulnerabilities][vulnerabilities-badge]][vulnerabilities-url]
 [![Licence][license-badge]][license-url]
 
 ## Introduction
@@ -73,9 +74,13 @@ Core Interfaces's Maven group ID is `io.apimatic`, and its artifact ID is `core-
 
 [test-url]: https://github.com/apimatic/core-interfaces-java/actions/workflows/build-and-test.yml
 
-[code-climate-url]: https://codeclimate.com/github/apimatic/core-interfaces-java
+[maintainability-badge]: https://sonarcloud.io/api/project_badges/measure?project=apimatic_core-interfaces-java&metric=sqale_rating
 
-[maintainability-url]: https://api.codeclimate.com/v1/badges/71332f9af318d309c3dc/maintainability
+[maintainability-url]: https://sonarcloud.io/summary/new_code?id=apimatic_core-interfaces-java
+
+[vulnerabilities-badge]: https://sonarcloud.io/api/project_badges/measure?project=apimatic_core-interfaces-java&metric=vulnerabilities
+
+[vulnerabilities-url]: https://sonarcloud.io/summary/new_code?id=apimatic_core-interfaces-java
 
 [lint-badge]: https://github.com/apimatic/core-interfaces-java/actions/workflows/linter.yml/badge.svg
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,7 @@
+sonar.projectKey=apimatic_core-interfaces-java
+sonar.projectName=APIMatic JAVA Core Library Interfaces
+sonar.organization=apimatic
+sonar.host.url=https://sonarcloud.io
+sonar.sourceEncoding=UTF-8
+
+sonar.sources=src/main/java


### PR DESCRIPTION
This PR migrates the code analysis from Code Climate to SonarCloud. It also adds badges from SonarCloud in Readme.