### PR TITLE
feat(snapshot-release): add snapshot repository configuration

### DIFF
--- a/.github/workflows/snapshot-release.yml
+++ b/.github/workflows/snapshot-release.yml
@@ -1,0 +1,36 @@
+name: Snapshot Release To Maven Central
+run-name: Publishing Snapshot Package Version ${{ github.event.inputs.Version }}-SNAPSHOT
+
+on:
+  workflow_dispatch:
+    inputs:
+      Version:
+        description: "This input field requires version in format: x.y.z, where x => major version, y => minor version and z => patch version. Do not include -SNAPSHOT; it will be appended automatically by the workflow for snapshot releases."
+        required: true
+
+jobs:
+  publish:
+    name: Publish the Maven package
+    runs-on: ubuntu-latest
+    environment: Sandbox
+    steps:
+      - name: Check out git repository
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.ref_name }}
+
+      - name: Install Java and Maven setup
+        uses: actions/setup-java@v1
+        with:
+          java-version: 8
+
+      - name: Update version in POM
+        run: mvn -B versions:set -DnewVersion=${{ github.event.inputs.Version }}-SNAPSHOT -DgenerateBackupPoms=false
+      - name: Release to Maven Central
+        id: release
+        uses: samuelmeuli/action-maven-publish@v1
+        with:
+          gpg_private_key: ${{ secrets.OSSRH_GPG_SECRET_KEY  }}
+          gpg_passphrase: ${{ secrets.OSSRH_GPG_PASSPHRASE  }}
+          nexus_username: ${{ secrets.OSSRH_USERNAME  }}
+          nexus_password: ${{ secrets.OSSRH_PASSWORD }}

--- a/pom.xml
+++ b/pom.xml
@@ -192,4 +192,18 @@
 			<url>https://github.com/apimatic/core-interfaces-java/blob/main/LICENSE</url>
 		</license>
 	</licenses>
+
+	<repositories>
+		<repository>
+			<id>central-portal-snapshots</id>
+			<name>Central Portal Snapshots</name>
+			<url>https://central.sonatype.com/repository/maven-snapshots/</url>
+			<releases>
+				<enabled>false</enabled>
+			</releases>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+		</repository>
+	</repositories>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -193,17 +193,4 @@
 		</license>
 	</licenses>
 
-	<repositories>
-		<repository>
-			<id>central-portal-snapshots</id>
-			<name>Central Portal Snapshots</name>
-			<url>https://central.sonatype.com/repository/maven-snapshots/</url>
-			<releases>
-				<enabled>false</enabled>
-			</releases>
-			<snapshots>
-				<enabled>true</enabled>
-			</snapshots>
-		</repository>
-	</repositories>
 </project>


### PR DESCRIPTION
## What

Added <repository> entry for Central Portal Snapshots to pom.xml.
Configured to disable releases and enable snapshots.
Ensures Maven can resolve snapshot dependencies from https://central.sonatype.com/repository/maven-snapshots/.

## Why

Some dependencies are only available as snapshot versions during development.
Without this configuration, Maven cannot fetch snapshot artifacts from the central portal.
This update improves developer workflow and avoids manual repository configuration for each developer.