### PR TITLE
feat: add webhooks and callbacks support

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ Core Interfaces's Maven group ID is `io.apimatic`, and its artifact ID is `core-
 | [`ExceptionCreator`](./src/main/java/io/apimatic/coreinterfaces/type/functional/ExceptionCreator.java)                              | Functional interface to  create the SDK exception                                      |
 | [`Serializer`](./src/main/java/io/apimatic/coreinterfaces/type/functional/Serializer.java)                                          | Functional interface to  apply the serialization function                              |
 | [`ContextInitializer`](./src/main/java/io/apimatic/coreinterfaces/type/functional/ContextInitializer.java)                          | Functional Interface to apply the context initialization function for the response models |
+| [`SignatureVerifier`](./src/main/java/io/apimatic/coreinterfaces/security/SignatureVerifier.java)                                          | Defines a contract for verifying the signature of an HTTP request                              |
+| [`VerificationResult`](./src/main/java/io/apimatic/coreinterfaces/security/VerificationResult.java)                          | Represents the result of an operation that can either succeed or fail with an error message |
 
 ## Enumerations
 

--- a/src/main/java/io/apimatic/coreinterfaces/security/SignatureVerifier.java
+++ b/src/main/java/io/apimatic/coreinterfaces/security/SignatureVerifier.java
@@ -1,0 +1,19 @@
+package io.apimatic.coreinterfaces.security;
+
+import io.apimatic.coreinterfaces.http.request.Request;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Defines a contract for verifying the signature of an HTTP request.
+ */
+public interface SignatureVerifier {
+
+    /**
+     * Verifies the signature of the specified HTTP request.
+     *
+     * @param request The HTTP request data to verify.
+     * @return A {@link CompletableFuture} containing the outcome of the verification process.
+     */
+    CompletableFuture<VerificationResult> verifyAsync(Request request);
+}

--- a/src/main/java/io/apimatic/coreinterfaces/security/VerificationResult.java
+++ b/src/main/java/io/apimatic/coreinterfaces/security/VerificationResult.java
@@ -1,0 +1,76 @@
+package io.apimatic.coreinterfaces.security;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Represents the result of an operation that can either succeed
+ * or fail with an error message.
+ */
+public interface VerificationResult {
+
+    /**
+     * Indicates whether the verification succeeded.
+     *
+     * @return true if successful; false otherwise.
+     */
+    boolean isSuccess();
+
+    /**
+     * Gets the collection of error messages, if any.
+     * Always returns a read-only list (never null).
+     *
+     * @return unmodifiable list of errors, empty if success.
+     */
+    List<String> getErrors();
+
+    /**
+     * Creates a successful result.
+     *
+     * @return a success result
+     */
+    static VerificationResult success() {
+        return DefaultImpl.SUCCESS;
+    }
+
+    /**
+     * Creates a failed result with the given error messages.
+     *
+     * @param errors list of error messages
+     * @return a failure result
+     */
+    static VerificationResult failure(String... errors) {
+        return new DefaultImpl(errors);
+    }
+
+    /**
+     * Default hidden implementation inside the interface.
+     */
+    class DefaultImpl implements VerificationResult {
+        private static final VerificationResult SUCCESS = new DefaultImpl();
+
+        private final List<String> errors;
+
+        private DefaultImpl(String... errors) {
+            this.errors = Collections.unmodifiableList(errors != null ?
+                    Arrays.asList(errors) : Collections.emptyList());
+        }
+
+        @Override
+        public boolean isSuccess() {
+            return errors.isEmpty();
+        }
+
+        @Override
+        public List<String> getErrors() {
+            return errors;
+        }
+
+        @Override
+        public String toString() {
+            return isSuccess()
+                    ? "VerificationResult{success}"
+                    : "VerificationResult{errors=" + errors + "}";
+        }
+    }
+}


### PR DESCRIPTION
## What
What
Add webhooks and callbacks support in the Java SDK, enabling users to register, configure, and handle webhook/callback events directly through the SDK.

## Why

Provides seamless event-driven integration with external systems and improves developer experience by supporting standardized webhook and callback mechanisms.

## Type of change
Select multiple if applicable.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause a breaking change)
- [ ] Tests (adds or updates tests)
- [ ] Documentation (adds or updates documentation)
- [ ] Refactor (style improvements, performance improvements, code refactoring)
- [ ] Revert (reverts a commit)
- [ ] CI/Build (adds or updates a script, change in external dependencies)

## Dependency Change
No new dependencies are added.

## Breaking change
No breaking changes are introduced in this PR.

## Testing
No new tests are added, as none exist for this area yet.

## Checklist
- [x] My code follows the coding conventions
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added new unit tests
